### PR TITLE
Add support for multiple batteries

### DIFF
--- a/battery-charge-full
+++ b/battery-charge-full
@@ -1,3 +1,6 @@
 #!/bin/bash
-sudo tpacpi-bat -s ST 1 0
-sudo tpacpi-bat -s SP 1 0
+max_bat=`/usr/bin/acpi | wc -l`
+for i in `seq 1 $max_bat` ; do
+	sudo tpacpi-bat -s ST ${i} 0
+	sudo tpacpi-bat -s SP ${i} 0
+done

--- a/battery-force-charge
+++ b/battery-force-charge
@@ -1,5 +1,8 @@
 #!/bin/bash
 . /etc/battery-charge-levels
 BATTERY_START_CHARGE_LEVEL=$[ ${BATTERY_STOP_CHARGE_LEVEL} - 4 ];
-sudo tpacpi-bat -s ST 1 ${BATTERY_START_CHARGE_LEVEL}
-sudo tpacpi-bat -s SP 1 ${BATTERY_STOP_CHARGE_LEVEL}
+max_bat=`/usr/bin/acpi | wc -l`
+for i in `seq 1 $max_bat` ; do
+	sudo tpacpi-bat -s ST ${i} ${BATTERY_START_CHARGE_LEVEL}
+	sudo tpacpi-bat -s SP ${i} ${BATTERY_STOP_CHARGE_LEVEL}
+done

--- a/battery-get-charge-levels
+++ b/battery-get-charge-levels
@@ -1,3 +1,7 @@
 #!/bin/bash
-echo "start charging at $(sudo tpacpi-bat -g ST 1)";
-echo "stop charging at $(sudo tpacpi-bat -g SP 1)";
+max_bat=`/usr/bin/acpi | wc -l`
+for i in `seq 1 $max_bat` ; do
+        echo "battery $i:"
+	echo "start charging at $(sudo tpacpi-bat -g ST ${i})";
+	echo "stop charging at $(sudo tpacpi-bat -g SP ${i})";
+done

--- a/battery-set-normal-charge-levels
+++ b/battery-set-normal-charge-levels
@@ -1,4 +1,7 @@
 #!/bin/bash
 . /etc/battery-charge-levels
-sudo tpacpi-bat -s ST 1 ${BATTERY_START_CHARGE_LEVEL}
-sudo tpacpi-bat -s SP 1 ${BATTERY_STOP_CHARGE_LEVEL}
+max_bat=`/usr/bin/acpi | wc -l`
+for i in `seq 1 $max_bat` ; do
+	sudo tpacpi-bat -s ST ${i} ${BATTERY_START_CHARGE_LEVEL}
+	sudo tpacpi-bat -s SP ${i} ${BATTERY_STOP_CHARGE_LEVEL}
+done


### PR DESCRIPTION
Now loop through all detected batteries and run the same operations on all of
them. Battery detection is done with the /usr/bin/acpi command which is
packaged as "acpi" on Ubuntu. Tested on Ubuntu 16.04 and Lenovo T460s only.